### PR TITLE
ref: set cupy as top best option for fft interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.6.1
+ - ref: reorder best fft interface (#23, #24)
  - enh: dont allow ndarray backend and fftfilter mismatches (#19, #20)
 0.6.0
  - feat: make codebase ndarray backend agnostic (#17,#18)

--- a/qpretrieve/fourier/__init__.py
+++ b/qpretrieve/fourier/__init__.py
@@ -23,9 +23,9 @@ PREFERRED_INTERFACE = None
 def get_available_interfaces() -> list[Type[FFTFilter]]:
     """Return a list of available FFT algorithms"""
     interfaces = [
+        FFTFilterCupy,
         FFTFilterPyFFTW,
         FFTFilterNumpy,
-        FFTFilterCupy,
     ]
     interfaces_available = []
     for interface in interfaces:


### PR DESCRIPTION
Solves #23 .

Tested locally with and without cupy and pyfftw.